### PR TITLE
feat:학생부 출결 crud api 작성

### DIFF
--- a/backend/src/main/java/com/school/management/domain/attendance/controller/AttendanceController.java
+++ b/backend/src/main/java/com/school/management/domain/attendance/controller/AttendanceController.java
@@ -1,0 +1,73 @@
+package com.school.management.domain.attendance.controller;
+
+import com.school.management.domain.attendance.dto.*;
+import com.school.management.domain.attendance.service.AttendanceService;
+import com.school.management.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Attendance", description = "출결 관련 API")
+public class AttendanceController {
+
+    private final AttendanceService attendanceService;
+
+    // 출결 등록
+    @PostMapping("/api/v1/attendance")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN')")
+    @Operation(summary = "출결 등록", description = "학생 출결 기록 등록 [TEACHER, ADMIN]")
+    public ResponseEntity<ApiResponse<Void>> createAttendance(
+            @Valid @RequestBody AttendanceCreateRequest request) {
+        attendanceService.createAttendance(request);
+        return ResponseEntity.ok(ApiResponse.success("출결 등록 성공"));
+    }
+
+    // 출결 내역 조회
+    @GetMapping("/api/v1/students/{studentId}/attendance")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN', 'STUDENT', 'PARENT')")
+    @Operation(summary = "출결 내역 조회", description = "학생별 전체 출결 기록 조회")
+    public ResponseEntity<ApiResponse<List<AttendanceResponse>>> getAttendances(
+            @PathVariable Long studentId) {
+        return ResponseEntity.ok(ApiResponse.success("출결 조회 성공",
+                attendanceService.getAttendances(studentId)));
+    }
+
+    // 출결 요약 조회
+    @GetMapping("/api/v1/students/{studentId}/attendance/summary")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN', 'STUDENT', 'PARENT')")
+    @Operation(summary = "출결 요약 조회", description = "학생별 출석/결석 일수 요약")
+    public ResponseEntity<ApiResponse<AttendanceSummaryResponse>> getAttendanceSummary(
+            @PathVariable Long studentId) {
+        return ResponseEntity.ok(ApiResponse.success("출결 요약 조회 성공",
+                attendanceService.getAttendanceSummary(studentId)));
+    }
+
+    // 출결 수정
+    @PutMapping("/api/v1/attendance/{attendanceId}")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN')")
+    @Operation(summary = "출결 수정", description = "출결 기록 수정 [TEACHER, ADMIN]")
+    public ResponseEntity<ApiResponse<Void>> updateAttendance(
+            @PathVariable Long attendanceId,
+            @Valid @RequestBody AttendanceUpdateRequest request) {
+        attendanceService.updateAttendance(attendanceId, request);
+        return ResponseEntity.ok(ApiResponse.success("출결 수정 성공"));
+    }
+
+    // 출결 삭제
+    @DeleteMapping("/api/v1/attendance/{attendanceId}")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN')")
+    @Operation(summary = "출결 삭제", description = "출결 기록 삭제 (soft delete) [TEACHER, ADMIN]")
+    public ResponseEntity<ApiResponse<Void>> deleteAttendance(
+            @PathVariable Long attendanceId) {
+        attendanceService.deleteAttendance(attendanceId);
+        return ResponseEntity.ok(ApiResponse.success("출결 삭제 성공"));
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/attendance/dto/AttendanceCreateRequest.java
+++ b/backend/src/main/java/com/school/management/domain/attendance/dto/AttendanceCreateRequest.java
@@ -1,0 +1,23 @@
+package com.school.management.domain.attendance.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class AttendanceCreateRequest {
+
+    @NotNull
+    private Long studentId;
+
+    @NotNull
+    private LocalDate attendanceDate;
+
+    @NotNull
+    private Boolean isAttended;
+
+    private String reason;
+
+    private String note;
+}

--- a/backend/src/main/java/com/school/management/domain/attendance/dto/AttendanceResponse.java
+++ b/backend/src/main/java/com/school/management/domain/attendance/dto/AttendanceResponse.java
@@ -1,0 +1,26 @@
+package com.school.management.domain.attendance.dto;
+
+import com.school.management.domain.attendance.entity.Attendance;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class AttendanceResponse {
+
+    private final Long id;
+    private final Long studentId;
+    private final LocalDate attendanceDate;
+    private final Boolean isAttended;
+    private final String reason;
+    private final String note;
+
+    public AttendanceResponse(Attendance attendance) {
+        this.id = attendance.getId();
+        this.studentId = attendance.getStudent().getId();
+        this.attendanceDate = attendance.getAttendanceDate();
+        this.isAttended = attendance.getIsAttended();
+        this.reason = attendance.getReason();
+        this.note = attendance.getNote();
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/attendance/dto/AttendanceSummaryResponse.java
+++ b/backend/src/main/java/com/school/management/domain/attendance/dto/AttendanceSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.school.management.domain.attendance.dto;
+
+import lombok.Getter;
+
+@Getter
+public class AttendanceSummaryResponse {
+
+    private final int totalDays;
+    private final int attendedDays;
+    private final int absentDays;
+
+    public AttendanceSummaryResponse(int totalDays, int attendedDays) {
+        this.totalDays = totalDays;
+        this.attendedDays = attendedDays;
+        this.absentDays = totalDays - attendedDays;
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/attendance/dto/AttendanceUpdateRequest.java
+++ b/backend/src/main/java/com/school/management/domain/attendance/dto/AttendanceUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.school.management.domain.attendance.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class AttendanceUpdateRequest {
+
+    @NotNull
+    private LocalDate attendanceDate;
+
+    @NotNull
+    private Boolean isAttended;
+
+    private String reason;
+
+    private String note;
+}

--- a/backend/src/main/java/com/school/management/domain/attendance/entity/Attendance.java
+++ b/backend/src/main/java/com/school/management/domain/attendance/entity/Attendance.java
@@ -1,0 +1,57 @@
+package com.school.management.domain.attendance.entity;
+
+import com.school.management.domain.student.entity.Student;
+import com.school.management.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "attendance")
+public class Attendance extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    @Column(nullable = false)
+    private LocalDate attendanceDate;
+
+    @Column(nullable = false)
+    private Boolean isAttended;
+
+    @Column(length = 100)
+    private String reason;
+
+    @Column(columnDefinition = "TEXT")
+    private String note;
+
+    public Attendance(Student student, LocalDate attendanceDate,
+                      Boolean isAttended, String reason, String note) {
+        this.student = student;
+        this.attendanceDate = attendanceDate;
+        this.isAttended = isAttended;
+        this.reason = reason;
+        this.note = note;
+    }
+
+    public void update(LocalDate attendanceDate, Boolean isAttended,
+                       String reason, String note) {
+        this.attendanceDate = attendanceDate;
+        this.isAttended = isAttended;
+        this.reason = reason;
+        this.note = note;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/attendance/repository/AttendanceRepository.java
+++ b/backend/src/main/java/com/school/management/domain/attendance/repository/AttendanceRepository.java
@@ -1,0 +1,14 @@
+package com.school.management.domain.attendance.repository;
+
+import com.school.management.domain.attendance.entity.Attendance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+    List<Attendance> findAllByStudentIdAndIsDeletedFalse(Long studentId);
+
+    Optional<Attendance> findByIdAndIsDeletedFalse(Long id);
+}

--- a/backend/src/main/java/com/school/management/domain/attendance/service/AttendanceService.java
+++ b/backend/src/main/java/com/school/management/domain/attendance/service/AttendanceService.java
@@ -1,0 +1,84 @@
+package com.school.management.domain.attendance.service;
+
+import com.school.management.domain.attendance.dto.*;
+import com.school.management.domain.attendance.entity.Attendance;
+import com.school.management.domain.attendance.repository.AttendanceRepository;
+import com.school.management.domain.student.entity.Student;
+import com.school.management.domain.student.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AttendanceService {
+
+    private final AttendanceRepository attendanceRepository;
+    private final StudentRepository studentRepository;
+
+    // 출결 등록
+    @Transactional
+    public void createAttendance(AttendanceCreateRequest request) {
+        Student student = studentRepository.findByIdAndIsDeletedFalse(request.getStudentId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학생입니다."));
+
+        Attendance attendance = new Attendance(
+                student,
+                request.getAttendanceDate(),
+                request.getIsAttended(),
+                request.getReason(),
+                request.getNote()
+        );
+        attendanceRepository.save(attendance);
+    }
+
+    // 출결 내역 조회
+    @Transactional(readOnly = true)
+    public List<AttendanceResponse> getAttendances(Long studentId) {
+        studentRepository.findByIdAndIsDeletedFalse(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학생입니다."));
+
+        return attendanceRepository.findAllByStudentIdAndIsDeletedFalse(studentId)
+                .stream()
+                .map(AttendanceResponse::new)
+                .toList();
+    }
+
+    // 출결 요약 조회
+    @Transactional(readOnly = true)
+    public AttendanceSummaryResponse getAttendanceSummary(Long studentId) {
+        studentRepository.findByIdAndIsDeletedFalse(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학생입니다."));
+
+        List<Attendance> attendances = attendanceRepository.findAllByStudentIdAndIsDeletedFalse(studentId);
+        int totalDays = attendances.size();
+        int attendedDays = (int) attendances.stream().filter(Attendance::getIsAttended).count();
+
+        return new AttendanceSummaryResponse(totalDays, attendedDays);
+    }
+
+    // 출결 수정
+    @Transactional
+    public void updateAttendance(Long attendanceId, AttendanceUpdateRequest request) {
+        Attendance attendance = attendanceRepository.findByIdAndIsDeletedFalse(attendanceId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 출결 기록입니다."));
+
+        attendance.update(
+                request.getAttendanceDate(),
+                request.getIsAttended(),
+                request.getReason(),
+                request.getNote()
+        );
+    }
+
+    // 출결 삭제
+    @Transactional
+    public void deleteAttendance(Long attendanceId) {
+        Attendance attendance = attendanceRepository.findByIdAndIsDeletedFalse(attendanceId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 출결 기록입니다."));
+
+        attendance.delete();
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/school/management/domain/auth/controller/AuthController.java
@@ -58,6 +58,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<LoginResponse>> refresh(
             @Valid @RequestBody TokenRefreshRequest request) {
         LoginResponse response = authService.refresh(request);
+
         return ResponseEntity.ok(ApiResponse.success("토큰 재발급 성공", response));
     }
 

--- a/backend/src/main/java/com/school/management/domain/record/controller/StudentRecordController.java
+++ b/backend/src/main/java/com/school/management/domain/record/controller/StudentRecordController.java
@@ -1,0 +1,68 @@
+package com.school.management.domain.record.controller;
+
+import com.school.management.domain.record.dto.*;
+import com.school.management.domain.record.service.StudentRecordService;
+import com.school.management.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "StudentRecord", description = "학생부 관련 API")
+public class StudentRecordController {
+
+    private final StudentRecordService studentRecordService;
+
+    // 학생부 항목 추가
+    @PostMapping("/api/v1/students/{studentId}/records")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN')")
+    @Operation(summary = "학생부 항목 추가", description = "학생부 항목 추가 [TEACHER, ADMIN]")
+    public ResponseEntity<ApiResponse<Void>> createRecord(
+            @PathVariable Long studentId,
+            @Valid @RequestBody StudentRecordCreateRequest request,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long teacherId = Long.parseLong(userDetails.getUsername());
+        studentRecordService.createRecord(studentId, teacherId, request);
+        return ResponseEntity.ok(ApiResponse.success("학생부 항목 추가 성공"));
+    }
+
+    // 학생부 조회
+    @GetMapping("/api/v1/students/{studentId}/records")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN', 'STUDENT', 'PARENT')")
+    @Operation(summary = "학생부 조회", description = "학생별 학생부 전체 조회")
+    public ResponseEntity<ApiResponse<List<StudentRecordResponse>>> getRecords(
+            @PathVariable Long studentId) {
+        return ResponseEntity.ok(ApiResponse.success("학생부 조회 성공",
+                studentRecordService.getRecords(studentId)));
+    }
+
+    // 학생부 수정
+    @PutMapping("/api/v1/records/{recordId}")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN')")
+    @Operation(summary = "학생부 수정", description = "학생부 항목 수정 [TEACHER, ADMIN]")
+    public ResponseEntity<ApiResponse<Void>> updateRecord(
+            @PathVariable Long recordId,
+            @Valid @RequestBody StudentRecordUpdateRequest request) {
+        studentRecordService.updateRecord(recordId, request);
+        return ResponseEntity.ok(ApiResponse.success("학생부 수정 성공"));
+    }
+
+    // 학생부 삭제
+    @DeleteMapping("/api/v1/records/{recordId}")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN')")
+    @Operation(summary = "학생부 삭제", description = "학생부 항목 삭제 (soft delete) [TEACHER, ADMIN]")
+    public ResponseEntity<ApiResponse<Void>> deleteRecord(
+            @PathVariable Long recordId) {
+        studentRecordService.deleteRecord(recordId);
+        return ResponseEntity.ok(ApiResponse.success("학생부 삭제 성공"));
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/record/dto/StudentRecordCreateRequest.java
+++ b/backend/src/main/java/com/school/management/domain/record/dto/StudentRecordCreateRequest.java
@@ -1,0 +1,22 @@
+package com.school.management.domain.record.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class StudentRecordCreateRequest {
+
+    @NotBlank
+    private String category;
+
+    private String note;
+
+    @NotNull
+    private LocalDate recordDate;
+
+    @NotBlank
+    private String semester;
+}

--- a/backend/src/main/java/com/school/management/domain/record/dto/StudentRecordResponse.java
+++ b/backend/src/main/java/com/school/management/domain/record/dto/StudentRecordResponse.java
@@ -1,0 +1,30 @@
+package com.school.management.domain.record.dto;
+
+import com.school.management.domain.record.entity.StudentRecord;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class StudentRecordResponse {
+
+    private final Long id;
+    private final Long studentId;
+    private final Long createdById;
+    private final String createdByName;
+    private final String category;
+    private final String note;
+    private final LocalDate recordDate;
+    private final String semester;
+
+    public StudentRecordResponse(StudentRecord record) {
+        this.id = record.getId();
+        this.studentId = record.getStudent().getId();
+        this.createdById = record.getCreatedBy().getId();
+        this.createdByName = record.getCreatedBy().getName();
+        this.category = record.getCategory();
+        this.note = record.getNote();
+        this.recordDate = record.getRecordDate();
+        this.semester = record.getSemester();
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/record/dto/StudentRecordUpdateRequest.java
+++ b/backend/src/main/java/com/school/management/domain/record/dto/StudentRecordUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.school.management.domain.record.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class StudentRecordUpdateRequest {
+
+    @NotBlank
+    private String category;
+
+    private String note;
+
+    @NotNull
+    private LocalDate recordDate;
+
+    @NotBlank
+    private String semester;
+}

--- a/backend/src/main/java/com/school/management/domain/record/entity/StudentRecord.java
+++ b/backend/src/main/java/com/school/management/domain/record/entity/StudentRecord.java
@@ -1,0 +1,64 @@
+package com.school.management.domain.record.entity;
+
+import com.school.management.domain.auth.entity.User;
+import com.school.management.domain.student.entity.Student;
+import com.school.management.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "student_record")
+public class StudentRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "student_id", nullable = false)
+    private Student student;
+
+    // 작성 교사
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @Column(nullable = false, length = 50)
+    private String category;
+
+    @Column(columnDefinition = "TEXT")
+    private String note;
+
+    @Column(nullable = false)
+    private LocalDate recordDate;
+
+    @Column(nullable = false, length = 10)
+    private String semester;
+
+    public StudentRecord(Student student, User createdBy, String category,
+                         String note, LocalDate recordDate, String semester) {
+        this.student = student;
+        this.createdBy = createdBy;
+        this.category = category;
+        this.note = note;
+        this.recordDate = recordDate;
+        this.semester = semester;
+    }
+
+    public void update(String category, String note,
+                       LocalDate recordDate, String semester) {
+        this.category = category;
+        this.note = note;
+        this.recordDate = recordDate;
+        this.semester = semester;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/record/repository/StudentRecordRepository.java
+++ b/backend/src/main/java/com/school/management/domain/record/repository/StudentRecordRepository.java
@@ -1,0 +1,14 @@
+package com.school.management.domain.record.repository;
+
+import com.school.management.domain.record.entity.StudentRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StudentRecordRepository extends JpaRepository<StudentRecord, Long> {
+
+    List<StudentRecord> findAllByStudentIdAndIsDeletedFalse(Long studentId);
+
+    Optional<StudentRecord> findByIdAndIsDeletedFalse(Long id);
+}

--- a/backend/src/main/java/com/school/management/domain/record/service/StudentRecordService.java
+++ b/backend/src/main/java/com/school/management/domain/record/service/StudentRecordService.java
@@ -1,0 +1,78 @@
+package com.school.management.domain.record.service;
+
+import com.school.management.domain.auth.entity.User;
+import com.school.management.domain.auth.repository.UserRepository;
+import com.school.management.domain.record.dto.*;
+import com.school.management.domain.record.entity.StudentRecord;
+import com.school.management.domain.record.repository.StudentRecordRepository;
+import com.school.management.domain.student.entity.Student;
+import com.school.management.domain.student.repository.StudentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudentRecordService {
+
+    private final StudentRecordRepository studentRecordRepository;
+    private final StudentRepository studentRepository;
+    private final UserRepository userRepository;
+
+    // 학생부 항목 추가
+    @Transactional
+    public void createRecord(Long studentId, Long teacherId, StudentRecordCreateRequest request) {
+        Student student = studentRepository.findByIdAndIsDeletedFalse(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학생입니다."));
+
+        User teacher = userRepository.findById(teacherId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        StudentRecord record = new StudentRecord(
+                student,
+                teacher,
+                request.getCategory(),
+                request.getNote(),
+                request.getRecordDate(),
+                request.getSemester()
+        );
+        studentRecordRepository.save(record);
+    }
+
+    // 학생부 조회
+    @Transactional(readOnly = true)
+    public List<StudentRecordResponse> getRecords(Long studentId) {
+        studentRepository.findByIdAndIsDeletedFalse(studentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학생입니다."));
+
+        return studentRecordRepository.findAllByStudentIdAndIsDeletedFalse(studentId)
+                .stream()
+                .map(StudentRecordResponse::new)
+                .toList();
+    }
+
+    // 학생부 수정
+    @Transactional
+    public void updateRecord(Long recordId, StudentRecordUpdateRequest request) {
+        StudentRecord record = studentRecordRepository.findByIdAndIsDeletedFalse(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학생부 항목입니다."));
+
+        record.update(
+                request.getCategory(),
+                request.getNote(),
+                request.getRecordDate(),
+                request.getSemester()
+        );
+    }
+
+    // 학생부 삭제
+    @Transactional
+    public void deleteRecord(Long recordId) {
+        StudentRecord record = studentRecordRepository.findByIdAndIsDeletedFalse(recordId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 학생부 항목입니다."));
+
+        record.delete();
+    }
+}


### PR DESCRIPTION
## 개요                                                                                       
  학생부(StudentRecord) 및 출결(Attendance) 도메인 CRUD API 구현                                
                                                                                                
  ## 관련 이슈                                                                                  
  closes #28                                                                             
                                                                                              
  ## 변경 사항
  - `Attendance` 엔티티, Repository, Service, Controller 추가
    - POST /api/v1/attendance (출결 등록)                                                       
    - GET /api/v1/students/{id}/attendance (출결 내역 조회)                                     
    - GET /api/v1/students/{id}/attendance/summary (출결 요약 조회)                             
    - PUT /api/v1/attendance/{id} (출결 수정)                                                   
    - DELETE /api/v1/attendance/{id} (출결 삭제)                                              
  - `StudentRecord` 엔티티, Repository, Service, Controller 추가                                
    - POST /api/v1/students/{id}/records (학생부 항목 추가)                                   
    - GET /api/v1/students/{id}/records (학생부 조회)                                           
    - PUT /api/v1/records/{id} (학생부 수정)                                                  
    - DELETE /api/v1/records/{id} (학생부 삭제)    