### PR TITLE
[Feat] 레이더 차트용 과목별 성적 조회 API 구현

### DIFF
--- a/backend/src/main/java/com/school/management/domain/subject/controller/GradeController.java
+++ b/backend/src/main/java/com/school/management/domain/subject/controller/GradeController.java
@@ -1,6 +1,7 @@
 package com.school.management.domain.subject.controller;
 
 import com.school.management.domain.subject.dto.GradeCreateRequest;
+import com.school.management.domain.subject.dto.GradeRadarResponse;
 import com.school.management.domain.subject.dto.GradeUpdateRequest;
 import com.school.management.domain.subject.entity.Grade;
 import com.school.management.domain.subject.entity.SemesterSummary;
@@ -68,5 +69,14 @@ public class GradeController {
             @PathVariable Long studentId) {
         return ResponseEntity.ok(ApiResponse.success("학기 요약 조회 성공",
                 gradeService.getStudentSemesterSummaries(studentId)));
+    }
+
+    // 레이더 차트용 과목별 성적 조회
+    @GetMapping("/students/{studentId}/radar")
+    @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN', 'STUDENT', 'PARENT')")
+    public ResponseEntity<ApiResponse<List<GradeRadarResponse>>> getStudentRadarGrades(
+            @PathVariable Long studentId) {
+        return ResponseEntity.ok(ApiResponse.success("레이더 차트 성적 조회 성공",
+                gradeService.getStudentRadarGrades(studentId)));
     }
 }

--- a/backend/src/main/java/com/school/management/domain/subject/dto/GradeRadarResponse.java
+++ b/backend/src/main/java/com/school/management/domain/subject/dto/GradeRadarResponse.java
@@ -1,0 +1,18 @@
+package com.school.management.domain.subject.dto;
+
+import com.school.management.domain.subject.entity.Grade;
+import lombok.Getter;
+
+@Getter
+public class GradeRadarResponse {
+
+    private final String subjectName;
+    private final String achievementLevel;
+    private final Integer rankGrade;
+
+    public GradeRadarResponse(Grade grade) {
+        this.subjectName = grade.getClassStatistic().getSubject().getSubjectName();
+        this.achievementLevel = grade.getAchievementLevel();
+        this.rankGrade = grade.getRankGrade();
+    }
+}

--- a/backend/src/main/java/com/school/management/domain/subject/service/GradeService.java
+++ b/backend/src/main/java/com/school/management/domain/subject/service/GradeService.java
@@ -5,6 +5,7 @@ import com.school.management.domain.student.repository.StudentRepository;
 import com.school.management.domain.subject.entity.ClassStatistic;
 import com.school.management.domain.subject.entity.Grade;
 import com.school.management.domain.subject.entity.SemesterSummary;
+import com.school.management.domain.subject.dto.GradeRadarResponse;
 import com.school.management.domain.subject.repository.ClassStatisticRepository;
 import com.school.management.domain.subject.repository.GradeRepository;
 import com.school.management.domain.subject.repository.SemesterSummaryRepository;
@@ -175,5 +176,14 @@ public class GradeService {
     @Transactional(readOnly = true)
     public List<SemesterSummary> getStudentSemesterSummaries(Long studentId) {
         return semesterSummaryRepository.findAllByStudentIdAndIsDeletedFalse(studentId);
+    }
+
+    // 레이더 차트용 과목별 성적 조회
+    @Transactional(readOnly = true)
+    public List<GradeRadarResponse> getStudentRadarGrades(Long studentId) {
+        return gradeRepository.findAllByStudentIdAndIsDeletedFalse(studentId)
+                .stream()
+                .map(GradeRadarResponse::new)
+                .toList();
     }
 }


### PR DESCRIPTION
## 개요
  레이더 차트용 과목별 성적 조회 API 구현 

## 관련 이슈
closes #30

## 변경 사항
 - GradeRadarResponse DTO 추가 (과목명·성취도·석차등급)                                      
 - GradeService.getStudentRadarGrades() 추가           
 - GET /api/grades/students/{id}/radar 엔드포인트 추가   