### PR TITLE
semester 파라미터 추가,Redis 캐싱

### DIFF
--- a/backend/src/main/java/com/school/management/domain/subject/controller/GradeController.java
+++ b/backend/src/main/java/com/school/management/domain/subject/controller/GradeController.java
@@ -75,8 +75,9 @@ public class GradeController {
     @GetMapping("/students/{studentId}/radar")
     @PreAuthorize("hasAnyRole('TEACHER', 'ADMIN', 'STUDENT', 'PARENT')")
     public ResponseEntity<ApiResponse<List<GradeRadarResponse>>> getStudentRadarGrades(
-            @PathVariable Long studentId) {
+            @PathVariable Long studentId,
+            @RequestParam String semester) {
         return ResponseEntity.ok(ApiResponse.success("레이더 차트 성적 조회 성공",
-                gradeService.getStudentRadarGrades(studentId)));
+                gradeService.getStudentRadarGrades(studentId, semester)));
     }
 }

--- a/backend/src/main/java/com/school/management/domain/subject/dto/GradeRadarResponse.java
+++ b/backend/src/main/java/com/school/management/domain/subject/dto/GradeRadarResponse.java
@@ -1,5 +1,7 @@
 package com.school.management.domain.subject.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.school.management.domain.subject.entity.Grade;
 import lombok.Getter;
 
@@ -14,5 +16,15 @@ public class GradeRadarResponse {
         this.subjectName = grade.getClassStatistic().getSubject().getSubjectName();
         this.achievementLevel = grade.getAchievementLevel();
         this.rankGrade = grade.getRankGrade();
+    }
+
+    @JsonCreator
+    public GradeRadarResponse(
+            @JsonProperty("subjectName") String subjectName,
+            @JsonProperty("achievementLevel") String achievementLevel,
+            @JsonProperty("rankGrade") Integer rankGrade) {
+        this.subjectName = subjectName;
+        this.achievementLevel = achievementLevel;
+        this.rankGrade = rankGrade;
     }
 }

--- a/backend/src/main/java/com/school/management/domain/subject/repository/GradeRepository.java
+++ b/backend/src/main/java/com/school/management/domain/subject/repository/GradeRepository.java
@@ -2,6 +2,8 @@ package com.school.management.domain.subject.repository;
 
 import com.school.management.domain.subject.entity.Grade;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -17,4 +19,8 @@ public interface GradeRepository extends JpaRepository<Grade, Long> {
 
     // 같은 반 + 과목 통계 기준 전체 성적 (석차등급 계산용)
     List<Grade> findAllByClassStatisticIdAndIsDeletedFalse(Long classStatisticId);
+
+    // 학생 + 학기 기준 성적 조회 (레이더 차트용)
+    @Query("SELECT g FROM Grade g WHERE g.student.id = :studentId AND g.classStatistic.semester = :semester AND g.isDeleted = false")
+    List<Grade> findAllByStudentIdAndSemesterAndIsDeletedFalse(@Param("studentId") Long studentId, @Param("semester") String semester);
 }

--- a/backend/src/main/java/com/school/management/domain/subject/service/GradeService.java
+++ b/backend/src/main/java/com/school/management/domain/subject/service/GradeService.java
@@ -11,6 +11,8 @@ import com.school.management.domain.subject.repository.GradeRepository;
 import com.school.management.domain.subject.repository.SemesterSummaryRepository;
 import com.school.management.domain.subject.repository.SubjectRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,6 +31,7 @@ public class GradeService {
     private final SubjectRepository subjectRepository;
 
     @Transactional
+    @CacheEvict(value = "grades:radar", allEntries = true)
     public void registerGrade(Long studentId, Long classStatisticId, BigDecimal rawScore) {
 
         Student student = studentRepository.findByIdAndIsDeletedFalse(studentId)
@@ -141,6 +144,7 @@ public class GradeService {
 
     // 성적 수정 — 원점수 변경 시 성취도·석차등급·학기요약 자동 재계산
     @Transactional
+    @CacheEvict(value = "grades:radar", allEntries = true)
     public void updateGrade(Long gradeId, BigDecimal rawScore) {
         Grade grade = gradeRepository.findById(gradeId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성적입니다."));
@@ -158,6 +162,7 @@ public class GradeService {
 
     // 성적 삭제 (soft delete) — 삭제 후 학기 요약 재계산
     @Transactional
+    @CacheEvict(value = "grades:radar", allEntries = true)
     public void deleteGrade(Long gradeId) {
         Grade grade = gradeRepository.findById(gradeId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 성적입니다."));
@@ -178,10 +183,11 @@ public class GradeService {
         return semesterSummaryRepository.findAllByStudentIdAndIsDeletedFalse(studentId);
     }
 
-    // 레이더 차트용 과목별 성적 조회
+    // 레이더 차트용 과목별 성적 조회 (학기별, Redis 캐싱)
     @Transactional(readOnly = true)
-    public List<GradeRadarResponse> getStudentRadarGrades(Long studentId) {
-        return gradeRepository.findAllByStudentIdAndIsDeletedFalse(studentId)
+    @Cacheable(value = "grades:radar", key = "#studentId + ':' + #semester")
+    public List<GradeRadarResponse> getStudentRadarGrades(Long studentId, String semester) {
+        return gradeRepository.findAllByStudentIdAndSemesterAndIsDeletedFalse(studentId, semester)
                 .stream()
                 .map(GradeRadarResponse::new)
                 .toList();

--- a/backend/src/main/java/com/school/management/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/school/management/global/config/RedisConfig.java
@@ -1,0 +1,32 @@
+package com.school.management.global.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory factory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(factory)
+                .cacheDefaults(config)
+                .build();
+    }
+}


### PR DESCRIPTION
## 개요
레이더 차트 API에 학기 필터 파라미터 추가 및 Redis 캐싱 적용
                                                                                                
## 관련 이슈                                                                                  
closes #34                                                                                     
                                                            
## 변경 사항                                                                                  
- GET /api/grades/students/{id}/radar?semester= 학기 파라미터 추가
- RedisConfig 추가 — RedisCacheManager TTL 10분 설정                                        
- GradeService.getStudentRadarGrades() @Cacheable 적용 (캐시 키:                          
  grades:radar:{studentId}:{semester}`)                                                        
- 성적 등록/수정/삭제 시 @CacheEvict로 캐시 무효화                                          
- GradeRepository 학기별 성적 조회 쿼리 추가                                                
- GradeRadarResponse Jackson 역직렬화용 @JsonCreator 생성자 추가     